### PR TITLE
Fix for vessels launching into orbit around the black hole.

### DIFF
--- a/src/Creator/Star.cs
+++ b/src/Creator/Star.cs
@@ -7,7 +7,7 @@ namespace StarSystems.Creator
     public class Star
     {
         private StarSystemDefintion defintion;
-        public Star(StarSystemDefintion star, PSystemBody InternalStarPSB,PSystemBody InternalSunPSB)
+        public Star(StarSystemDefintion star, PSystemBody InternalStarPSB, PSystemBody InternalSunPSB)
         {
             defintion = star;
             var InternalStarCB = InternalStarPSB.celestialBody;

--- a/src/Fixes/GameFixer.cs
+++ b/src/Fixes/GameFixer.cs
@@ -26,14 +26,14 @@ namespace StarSystems.Fixes
                     {
                         PatchedSaveGames.GetNode("PatchedSaveGames").AddValue(HighLogic.CurrentGame.Title, "Patched");
                         PatchedSaveGames.Save("GameData/StarSystems/Config/PatchedSaveGames.cfg");
-                        foreach (var Vessel in FlightGlobals.Vessels)
+                        foreach (var vessel in FlightGlobals.Vessels)
                         {
-                            if (Vessel.orbitDriver.orbit.referenceBody == StarSystem.CBDict["Sun"])
+                            if (vessel.orbitDriver.orbit.referenceBody == StarSystem.CBDict["Sun"])
                             {
-                                Debug.Log("Patching " + Vessel.name);
-                                Vessel.orbitDriver.referenceBody = StarSystem.CBDict["Kerbol"];
-                                Vessel.orbitDriver.UpdateOrbit();
-                                Debug.Log(Vessel.name + "Patched");
+                                Debug.Log("Patching " + vessel.name);
+                                vessel.orbitDriver.referenceBody = StarSystem.CBDict["Kerbol"];
+                                vessel.orbitDriver.UpdateOrbit();
+                                Debug.Log(vessel.name + "Patched");
                             }
                         }
                     }

--- a/src/Fixes/OrbitUpdater.cs
+++ b/src/Fixes/OrbitUpdater.cs
@@ -11,8 +11,10 @@ namespace StarSystems.Fixes
         void Update()
         {
 			if (StarSystem.Initialized) {
-				foreach (var Orb in Planetarium.Orbits) {
-					Orb.UpdateOrbit ();
+				foreach (var orb in Planetarium.Orbits) {
+					if (orb.celestialBody != null) {
+						orb.UpdateOrbit ();
+					}
 				}
 			}
         }

--- a/src/Fixes/OrbitUpdater.cs
+++ b/src/Fixes/OrbitUpdater.cs
@@ -10,12 +10,9 @@ namespace StarSystems.Fixes
     {
         void Update()
         {
-            if (FlightGlobals.ActiveVessel != null)
+            foreach (var Orb in Planetarium.Orbits)
             {
-                foreach (var Orb in Planetarium.Orbits)
-                {
-                    Orb.UpdateOrbit();
-                }
+                Orb.UpdateOrbit();
             }
         }
     }

--- a/src/Fixes/OrbitUpdater.cs
+++ b/src/Fixes/OrbitUpdater.cs
@@ -10,10 +10,11 @@ namespace StarSystems.Fixes
     {
         void Update()
         {
-            foreach (var Orb in Planetarium.Orbits)
-            {
-                Orb.UpdateOrbit();
-            }
+			if (StarSystem.Initialized) {
+				foreach (var Orb in Planetarium.Orbits) {
+					Orb.UpdateOrbit ();
+				}
+			}
         }
     }
 }

--- a/src/StarSystem.cs
+++ b/src/StarSystem.cs
@@ -94,6 +94,8 @@ namespace StarSystems
                         //Set sun to Kerbol when loading space center
                         StarLightSwitcher.setSun(CBDict["Kerbol"]);
                         break;
+					case 6: // VAB/SPH
+						break;
                     case 2://main menu
                         Initialized = false;
                         break;
@@ -151,19 +153,21 @@ namespace StarSystems
             Debug.Log("Starlight controller created");
 
             //Create Navball fixer
-            var NavBallFixerObj = new GameObject("NavBallFixer", typeof (NavBallFixer));
-            GameObject.DontDestroyOnLoad(NavBallFixerObj);
+            var navBallFixerObj = new GameObject("NavBallFixer", typeof (NavBallFixer));
+            GameObject.DontDestroyOnLoad(navBallFixerObj);
 
             Debug.Log("Navball fixer created");
 
             //Create Vessel fixer
-            var VesselFixerObj = new GameObject("SaveGameFixer", typeof (GameFixer));
-            GameObject.DontDestroyOnLoad(VesselFixerObj);
+            var vesselFixerObj = new GameObject("SaveGameFixer", typeof (GameFixer));
+            GameObject.DontDestroyOnLoad(vesselFixerObj);
 
             Debug.Log("Vessel fixer created");
 
-            //var OrbitUpdater = new GameObject("OrbitUpdater", typeof(OrbitUpdater));
-            //GameObject.DontDestroyOnLoad(OrbitUpdater);
+            var orbitUpdater = new GameObject("OrbitUpdater", typeof(OrbitUpdater));
+			GameObject.DontDestroyOnLoad(orbitUpdater);
+
+			Debug.Log("Orbit updater created");
 
             //As much as I would like to name it "Kerbol" keeping the name as "Sun" will maximize mod compatibility
             CBDict["Kerbol"].bodyName = "Sun";


### PR DESCRIPTION
This fixes launches at least.  During testing I still had once instance where a ship in orbit around Minmus got teleported into an orbit around the black hole.  I'm not sure why OrbitUpdater was commented out, I'm slightly worried it may have been causing other problems. @medsouz do you know any more about what it was originally trying to fix (since with the check for having a loaded vessel it wasn't fixing this problem)?
